### PR TITLE
Update to version 24.7a6

### DIFF
--- a/de.z_ray.Facetracker.json
+++ b/de.z_ray.Facetracker.json
@@ -23,7 +23,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/Z-Ray-Entertainment/Facetracker/releases/download/24.7a4/osf_pre_build.zip",
+          "url": "https://github.com/Z-Ray-Entertainment/Facetracker/releases/download/24.7a6/osf_pre_build.zip",
           "sha256": "98cda3bc8bd275edc630d83e687e098460d3bd857155069beef1cd24a74287c3"
         }
       ]
@@ -36,7 +36,7 @@
         {
           "type": "git",
           "url": "https://github.com/Z-Ray-Entertainment/Facetracker",
-          "tag": "24.7a4"
+          "tag": "24.7a6"
         }
       ]
     }


### PR DESCRIPTION
Update to version 24.7a6

- Primarily this update includes flathub's quality guideline fixes
- Minor refactor of the ui
- New screenshots